### PR TITLE
feat: Implement initial context for deep research

### DIFF
--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -34,4 +34,11 @@ export const migrations: Migration[] = [
 			add duration integer;
     `,
 	},
+	{
+		name: "0004_add_initial_learnings_column.sql",
+		sql: `
+		ALTER TABLE researches
+		ADD COLUMN initialLearnings TEXT;
+    `,
+	},
 ];

--- a/src/static/core.js
+++ b/src/static/core.js
@@ -38,6 +38,8 @@ function loadNewResearch() {
 		document.getElementById("depth-hidden").value = originalDepth;
 		const originalBreadth = document.getElementById("initial-breadth").value;
 		document.getElementById("breadth-hidden").value = originalBreadth;
+		const initialLearnings = document.getElementById("initial-learnings").value;
+		document.getElementById("initial-learnings-hidden").value = initialLearnings;
 
 		// Add event listener to start research button when it's created
 		setTimeout(() => {

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -411,6 +411,19 @@ export const ResearchDetails: FC = (props) => {
 							</div>
 						</div>
 
+						{props.research.initialLearnings && props.research.initialLearnings.trim() !== "" && (
+							<div>
+								<h4 className="font-semibold text-gray-900 mb-2">
+									Initial Learnings
+								</h4>
+								<div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 rounded-r-md">
+									{props.research.initialLearnings.split('\n').map((line: string, index: number) => (
+										<p key={index} className="text-gray-800">{line}</p>
+									))}
+								</div>
+							</div>
+						)}
+
 						<div>
 							<h4 className="font-semibold text-gray-900 mb-3">
 								Follow-up Questions & Answers

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -478,6 +478,24 @@ export const CreateResearch: FC = () => {
 							follow-up questions to gather relevant information.
 						</p>
 					</div>
+					<div class="mb-6">
+						<label
+							htmlFor="initial-learnings"
+							className="block text-sm font-medium text-gray-700 mb-2"
+						>
+							Initial Learnings (Optional)
+						</label>
+						<textarea
+							id="initial-learnings"
+							name="initial-learnings"
+							rows={4}
+							className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-none"
+							placeholder="Enter any initial data or learnings you have, one per line..."
+						></textarea>
+						<p className="mt-2 text-sm text-gray-500">
+							Providing initial learnings can help the AI generate more relevant and insightful questions.
+						</p>
+					</div>
 					<div className="flex">
 						<div className="grow mr-2">
 							<label
@@ -517,7 +535,7 @@ export const CreateResearch: FC = () => {
 						id="generate-questions-btn"
 						hx-post="/create/questions"
 						hx-target="#followup-section"
-						hx-include="#initial-query"
+						hx-include="#initial-query, #initial-learnings"
 						hx-indicator="#loading-questions"
 						class="px-6 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
 					>
@@ -563,6 +581,7 @@ export const CreateResearch: FC = () => {
 				<input type="hidden" name="query" id="original-query-hidden" />
 				<input type="hidden" name="depth" id="depth-hidden" />
 				<input type="hidden" name="breadth" id="breadth-hidden" />
+				<input type="hidden" name="initial-learnings" id="initial-learnings-hidden" />
 			</form>
 		</main>
 	);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type ResearchType = {
 	result?: string;
 	created_at?: string;
 	start_ms?: number;
+	initialLearnings?: string;
 };
 
 export type ResearchTypeDB = {
@@ -26,4 +27,5 @@ export type ResearchTypeDB = {
 	questions: string;
 	result?: string;
 	created_at?: string;
+	initialLearnings?: string;
 };


### PR DESCRIPTION
This commit introduces a feature that allows you to provide initial data/learnings when creating a new deep research project.

Key changes:

- Added an optional "Initial Learnings" textarea to the new research page.
- Updated the `ResearchType` and `ResearchTypeDB` types to include an `initialLearnings` field.
- Modified the `CreateResearch` component in `src/templates/layout.tsx` to include the new textarea and pass its value during form submission.
- Updated `src/static/core.js` to handle the new field in the form.
- Modified the `ResearchWorkflow` in `src/workflows.ts` to:
    - Receive `initialLearnings` from the event payload.
    - Split the `initialLearnings` string by newlines.
    - Pass the resulting array to the `deepResearch` function to prefill the learnings.

This allows you to seed the research process with existing knowledge, potentially leading to more focused and relevant reports.