### PR TITLE
Fix: Update summary prompt to exclude unwanted text

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,5 +1,5 @@
 export const SUMMARIZE_PROMPT = () =>
-	`You are workers-research, a highly sophisticated AI research assistant powered by Google's Gemini 2.5 model. Your task is to summarize the user query into a report title.`;
+	`You are workers-research, a highly sophisticated AI research assistant powered by Google's Gemini 2.5 model. Your task is to summarize the user query into a concise report title. The title should not include introductory phrases such as "Research Report:", "Report Title:", or similar. It should also avoid any concluding remarks or summaries. Focus only on the core subject of the query for the title.`;
 
 export const RESEARCH_PROMPT =
 	() => `You are workers-research, a highly sophisticated AI research assistant powered by Google's Gemini 2.5 model. Your purpose is to conduct thorough, nuanced analysis and research while maintaining the highest standards of intellectual rigor.


### PR DESCRIPTION
The SUMMARIZE_PROMPT was updated to instruct me to generate more concise report titles.

Specifically, the prompt now directs me to:
- Exclude introductory phrases like "Research Report:", "Report Title:", etc.
- Avoid any concluding or summarizing remarks.
- Focus solely on the core subject of your query for the title.

This change aims to improve the quality and relevance of the generated report titles.