### PR TITLE
Fix: Improve research history and details page UI/UX

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -417,7 +417,7 @@ app.get("/research/:id/status", async (c) => {
 		)
 		.where("research_id = ?", id)
 		.orderBy("timestamp desc")
-		.limit(10)
+		.limit(5)
 		.all();
 
 	if (!history.results || history.results.length === 0) {

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -32,24 +32,27 @@ export const ResearchStatusHistoryDisplay: FC<{
 	return (
 		// Removed mt-8, h3 title, and outer div. The parent container will handle margins.
 		// The hx-swap will replace the content of the container, so the title should be outside.
-		<ul class="space-y-2">
+		<ul class="space-y-3">
 			{props.statusHistory.map((entry, index) => (
-				<li key={index} class="flex items-start p-2 bg-gray-50 rounded-md">
+				<li
+					key={index}
+					class="flex items-start p-3 bg-white rounded-md border border-gray-200 hover:bg-gray-50 transition-colors duration-150"
+				>
 					<svg
-						class="h-4 w-4 text-gray-500 mr-3 flex-shrink-0 mt-1"
+						class="h-5 w-5 text-blue-500 mr-3 flex-shrink-0"
 						fill="currentColor"
 						viewBox="0 0 20 20"
 						aria-hidden="true"
 					>
 						<path
 							fill-rule="evenodd"
-							d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+							d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1.25-7.25a1.25 1.25 0 112.5 0 1.25 1.25 0 01-2.5 0z"
 							clip-rule="evenodd"
 						></path>
 					</svg>
-					<span class="text-sm text-gray-800">
+					<span class="text-sm text-gray-700">
 						{entry.status_text}
-						<span class="block text-xs text-gray-500 mt-0.5">
+						<span class="block text-xs text-gray-500 mt-1">
 							{new Date(entry.timestamp).toLocaleString()}
 						</span>
 					</span>
@@ -477,7 +480,7 @@ export const ResearchDetails: FC = (props) => {
 			)}
 
 			<div className="mb-8">
-				<details className="group" open>
+				<details className="group">
 					<summary className="flex items-center gap-2 px-4 py-3 bg-gray-100 rounded-lg cursor-pointer hover:bg-gray-200 transition-colors">
 						<svg
 							className="w-4 h-4 text-gray-600 transition-transform group-open:rotate-90"

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -318,6 +318,15 @@ async function addResearchStatusHistoryEntry(
 	researchId: string,
 	statusText: string,
 ) {
+	const messagesToFilter = [
+		"Generating SERP queries for research",
+		"processing serp results",
+	];
+
+	if (messagesToFilter.some(msg => statusText.includes(msg))) {
+		return;
+	}
+
 	try {
 		await db
 			.insert({


### PR DESCRIPTION
This commit addresses several UI/UX issues on the research history and details pages:

1.  **Filter Status Messages:**
    - Messages "Generating SERP queries for research" and "processing serp results" are now filtered out from the live status history display on the research details page. This is achieved by preventing these messages from being saved to the database in the `addResearchStatusHistoryEntry` function.

2.  **Collapse Research Context by Default:**
    - The "Research Context" section (containing the initial query and follow-up questions) on the research details page is now collapsed by default to provide a cleaner initial view. You can expand it by clicking.

3.  **Update Live Status Display:**
    - The number of live status updates shown on the research details page is now limited to the latest 5 entries (previously 10).
    - The visual styling of the status history has been modernized:
        - Increased padding and added a hover effect to list items.
        - Changed the icon to a filled circle for a cleaner look. - Improved typography and spacing for better readability.

These changes enhance your experience by making the research details page less cluttered and the status updates more focused and visually appealing. I've ensured all changes function as expected.