### PR TITLE
feat: Display research history for completed/errored researches

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -273,7 +273,7 @@ app.get("/details/:id", async (c) => {
 		.replaceAll("```", "");
 
 	let statusHistory: any[] = [];
-	if (resp.results && resp.results.status === 1) {
+	if (resp.results && (resp.results.status === 1 || resp.results.status === 2 || resp.results.status === 3)) {
 		const historyQb = new D1QB(c.env.DB);
 		const historyResult = await historyQb
 			.select<{ status_text: string; timestamp: string }>(

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -609,6 +609,16 @@ export const ResearchDetails: FC = (props) => {
 				</div>
 			)}
 
+			{/* Add this new section for research history */}
+			{(researchData.status === 2 || researchData.status === 3) && researchData.statusHistory && researchData.statusHistory.length > 0 && (
+			  <details className="mt-4 mb-8">
+			    <summary className="cursor-pointer font-semibold text-gray-800 mb-3">Research History</summary>
+			    <div className="mt-2">
+			      <ResearchStatusHistoryDisplay statusHistory={researchData.statusHistory} />
+			    </div>
+			  </details>
+			)}
+
 			{/* Report Content - direct child of main */}
 			{researchData.status !== 1 && (
 				<div className="prose prose-lg max-w-none">


### PR DESCRIPTION
Adds a collapsible section to the research details page to display the research history.

This section is only visible when the research is completed or in an error state. The history is fetched from the `research_status_history` table and displayed using the `ResearchStatusHistoryDisplay` component. The section is collapsed by default.