### PR TITLE
Add inline Q&A panel for completed research reports

### DIFF
--- a/.changeset/inline-qa-panel.md
+++ b/.changeset/inline-qa-panel.md
@@ -1,0 +1,5 @@
+---
+"workers-research": minor
+---
+
+Add inline Q&A panel for completed research reports. Users can now ask follow-up questions about a finished report directly from the details page. Answers are grounded in the report content and saved to D1 for future reference. Also moves `isRateLimitError` and `getRetryDelay` helpers to `utils.ts` for reuse across the app.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **Intuitive Dashboard:** Manage and view research via a Hono/JSX web interface.
 - **Simplified Architecture:** Gemini 2.5's large context window removes the need for prompt compression, enhancing report quality.
 - **AutoRAG Integration:** Allows the system to perform research using Cloudflare AI's AutoRAG feature, which queries against a pre-indexed dataset. This can be used as an alternative or in conjunction with standard web browsing research. The AutoRAG feature is invoked when an `autorag_id` is provided with the research request.
+- **Inline Q&A:** Ask follow-up questions about completed reports, with answers grounded in the report content and saved for future reference.
 
 ## 🚀 Inspiration and Acknowledgements
 
@@ -171,7 +172,12 @@ Follow these steps to set up and run `workers-research` on your Cloudflare accou
    - Once a research is complete, a "Read" button will appear next to it.
    - Click "Read" to view the generated research report in a nicely formatted HTML page.
 
-5. **Re-run Researches:**
+5. **Ask Follow-up Questions:**
+   - On the research details page of a completed report, scroll to the "Ask a follow-up question" panel.
+   - Type a question about the report (e.g. "What are the main risks identified?" or "Which companies were mentioned most?").
+   - Answers are grounded in the report content and saved for future reference.
+
+6. **Re-run Researches:**
    - If you want to re-run a previous research, click the "🔄" button next to the research entry. This will create a new research based on the same query and parameters.
 
 ## 📊 Performance & Limitations

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,7 +35,9 @@ import type { ResearchType, ResearchTypeDB } from "./types";
 import {
 	buildSearchFilters,
 	formatDuration,
+	getFallbackModel,
 	getModel,
+	isRateLimitError,
 	normalizeDomain,
 	safeJsonParse,
 } from "./utils";
@@ -809,11 +811,36 @@ app.post("/details/:id/ask", async (c) => {
 		throw new HTTPException(400, { message: "Report content not available" });
 	}
 
-	const { text: answer } = await generateText({
-		model: getModel(c.env),
-		system: REPORT_QA_PROMPT(),
-		prompt: `Research Report:\n\n${reportContent}\n\n---\n\nUser Question: ${question}`,
-	});
+	let answer: string;
+	try {
+		const result = await generateText({
+			model: getModel(c.env),
+			system: REPORT_QA_PROMPT(),
+			prompt: `Research Report:\n\n${reportContent}\n\n---\n\nUser Question: ${question}`,
+		});
+		answer = result.text;
+	} catch (err) {
+		if (isRateLimitError(err)) {
+			throw new HTTPException(429, {
+				message: "AI rate limit reached, please try again shortly",
+			});
+		}
+		try {
+			const result = await generateText({
+				model: getFallbackModel(c.env),
+				system: REPORT_QA_PROMPT(),
+				prompt: `Research Report:\n\n${reportContent}\n\n---\n\nUser Question: ${question}`,
+			});
+			answer = result.text;
+		} catch (fallbackErr) {
+			if (isRateLimitError(fallbackErr)) {
+				throw new HTTPException(429, {
+					message: "AI rate limit reached, please try again shortly",
+				});
+			}
+			throw new HTTPException(500, { message: "Failed to generate answer" });
+		}
+	}
 
 	const questionId = crypto.randomUUID();
 	await qb

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -811,6 +811,20 @@ app.post("/details/:id/ask", async (c) => {
 		throw new HTTPException(400, { message: "Report content not available" });
 	}
 
+	const MAX_QUESTIONS_PER_RESEARCH = 50;
+	const countResult = await qb
+		.fetchOne<{ count: number }>({
+			tableName: "research_questions",
+			fields: "COUNT(*) as count",
+			where: { conditions: ["research_id = ?"], params: [id] },
+		})
+		.execute();
+	if ((countResult.results?.count ?? 0) >= MAX_QUESTIONS_PER_RESEARCH) {
+		throw new HTTPException(429, {
+			message: `Maximum ${MAX_QUESTIONS_PER_RESEARCH} questions per research reached`,
+		});
+	}
+
 	let answer: string;
 	try {
 		const result = await generateText({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,11 @@ import {
 } from "./config";
 import { renderMarkdownReportContent, renderPdfDocument } from "./markdown";
 import { migrations } from "./migrations";
-import { FOLLOWUP_QUESTIONS_PROMPT, SUMMARIZE_PROMPT } from "./prompts";
+import {
+	FOLLOWUP_QUESTIONS_PROMPT,
+	REPORT_QA_PROMPT,
+	SUMMARIZE_PROMPT,
+} from "./prompts";
 import { getReportWithR2Resolution } from "./storage";
 import {
 	CloneResearch,
@@ -24,6 +28,7 @@ import {
 	NewResearchQuestions,
 	ResearchDetails,
 	ResearchList,
+	ResearchQAItem,
 	TopBar,
 } from "./templates/layout";
 import type { ResearchType, ResearchTypeDB } from "./types";
@@ -445,12 +450,35 @@ app.get("/details/:id", async (c) => {
 		statusHistory = historyResult.results || [];
 	}
 
+	let researchQuestions: Array<{
+		question: string;
+		answer_html: string;
+		created_at?: string;
+	}> = [];
+	if (resp.results.status === 2) {
+		const questionsQb = new D1QB(c.env.DB);
+		const questionsResult = await questionsQb
+			.select<{ question: string; answer: string; created_at: string }>(
+				"research_questions",
+			)
+			.where("research_id = ?", id)
+			.orderBy("created_at asc")
+			.all();
+		researchQuestions = (questionsResult.results || []).map((q) => ({
+			question: q.question,
+			answer_html: renderMarkdownReportContent(q.answer),
+			created_at: q.created_at,
+		}));
+	}
+
 	const researchProps = {
 		...resp.results,
 		questions: safeJsonParse(resp.results.questions, []),
 		report_html: renderMarkdownReportContent(content),
 		statusHistory: statusHistory,
 		isPartial: partial === "true",
+		researchQuestions,
+		csrfToken: c.get("csrfToken") ?? "",
 	};
 
 	if (partial === "true") {
@@ -739,6 +767,69 @@ app.get("/details/:id/download/json", async (c) => {
 	headers.set("Content-Disposition", 'attachment; filename="report.json"');
 
 	return new Response(JSON.stringify(exportData, null, 2), { headers });
+});
+
+app.post("/details/:id/ask", async (c) => {
+	const id = c.req.param("id");
+	const form = await c.req.formData();
+	const question = (form.get("question") as string | null)?.trim();
+
+	if (!question || question.length === 0) {
+		throw new HTTPException(400, { message: "Question is required" });
+	}
+	if (question.length > 2000) {
+		throw new HTTPException(400, {
+			message: "Question is too long (max 2000 chars)",
+		});
+	}
+
+	const qb = new D1QB(c.env.DB);
+	const resp = await qb
+		.fetchOne<ResearchTypeDB>({
+			tableName: "researches",
+			where: { conditions: ["id = ?"], params: [id] },
+		})
+		.execute();
+
+	if (!resp.results) {
+		throw new HTTPException(404, { message: "Research not found" });
+	}
+
+	if (resp.results.status !== 2) {
+		throw new HTTPException(400, { message: "Research is not yet complete" });
+	}
+
+	const reportContent = await getReportWithR2Resolution(
+		c.env.REPORTS_BUCKET,
+		id,
+		resp.results.result,
+	);
+
+	if (!reportContent) {
+		throw new HTTPException(400, { message: "Report content not available" });
+	}
+
+	const { text: answer } = await generateText({
+		model: getModel(c.env),
+		system: REPORT_QA_PROMPT(),
+		prompt: `Research Report:\n\n${reportContent}\n\n---\n\nUser Question: ${question}`,
+	});
+
+	const questionId = crypto.randomUUID();
+	await qb
+		.insert({
+			tableName: "research_questions",
+			data: { id: questionId, research_id: id, question, answer },
+		})
+		.execute();
+
+	return c.html(
+		<ResearchQAItem
+			question={question}
+			answer_html={renderMarkdownReportContent(answer)}
+			createdAt={new Date().toISOString()}
+		/>,
+	);
 });
 
 app.post("/re-run", async (c) => {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -131,4 +131,18 @@ export const migrations: Migration[] = [
 		ALTER TABLE researches ADD COLUMN excluded_domains TEXT;
 		`,
 	},
+	{
+		name: "0012_create_research_questions.sql",
+		sql: `
+		CREATE TABLE research_questions (
+		  id TEXT PRIMARY KEY,
+		  research_id TEXT NOT NULL,
+		  question TEXT NOT NULL,
+		  answer TEXT NOT NULL,
+		  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		  FOREIGN KEY (research_id) REFERENCES researches(id) ON DELETE CASCADE
+		);
+		CREATE INDEX IF NOT EXISTS idx_research_questions_research_id ON research_questions(research_id);
+		`,
+	},
 ];

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -287,3 +287,15 @@ Analyze the report and determine:
 If recommending additional research, provide 2-3 specific search queries that would address the most critical gaps.
 
 Be critical but fair in your assessment. The goal is to ensure the user receives a comprehensive, high-quality research report.`;
+
+export const REPORT_QA_PROMPT = () =>
+	`You are workers-research, an AI assistant helping a user explore a completed research report.
+
+You will be given the full text of a research report and a follow-up question from the user.
+
+Instructions:
+1. Answer ONLY based on information present in the report — do not use general knowledge outside the report.
+2. If the report does not contain enough information to answer the question, say so clearly.
+3. Be concise but complete. Use bullet points or short paragraphs as appropriate.
+4. Quote relevant sections when helpful (use > blockquote markdown).
+5. Do not re-summarize the entire report — focus on what the question asks.`;

--- a/src/static/core.js
+++ b/src/static/core.js
@@ -327,9 +327,10 @@ function toggleDropdown(id) {
 	}
 }
 
-async function submitQuestion(event, researchId) {
+async function submitQuestion(event) {
 	event.preventDefault();
 	const form = event.target;
+	const researchId = form.dataset.researchId;
 	const question = form.querySelector("#qa-question").value.trim();
 	if (!question) return;
 
@@ -337,6 +338,10 @@ async function submitQuestion(event, researchId) {
 	const loading = document.getElementById("qa-loading");
 	submitBtn.disabled = true;
 	loading.classList.remove("hidden");
+
+	const errorEl = document.getElementById("qa-error");
+	errorEl.textContent = "";
+	errorEl.classList.add("hidden");
 
 	const formData = new FormData(form);
 	try {
@@ -346,14 +351,15 @@ async function submitQuestion(event, researchId) {
 		});
 		if (!resp.ok) {
 			const text = await resp.text();
-			alert("Error: " + text);
+			errorEl.textContent = "Error: " + text;
+			errorEl.classList.remove("hidden");
 			return;
 		}
 		const html = await resp.text();
 		const history = document.getElementById("qa-history");
 		const div = document.createElement("div");
 		div.innerHTML = html;
-		history.appendChild(div.firstChild);
+		history.appendChild(div.firstElementChild);
 		form.querySelector("#qa-question").value = "";
 	} finally {
 		submitBtn.disabled = false;

--- a/src/static/core.js
+++ b/src/static/core.js
@@ -327,6 +327,40 @@ function toggleDropdown(id) {
 	}
 }
 
+async function submitQuestion(event, researchId) {
+	event.preventDefault();
+	const form = event.target;
+	const question = form.querySelector("#qa-question").value.trim();
+	if (!question) return;
+
+	const submitBtn = document.getElementById("qa-submit");
+	const loading = document.getElementById("qa-loading");
+	submitBtn.disabled = true;
+	loading.classList.remove("hidden");
+
+	const formData = new FormData(form);
+	try {
+		const resp = await fetch(`/details/${researchId}/ask`, {
+			method: "POST",
+			body: formData,
+		});
+		if (!resp.ok) {
+			const text = await resp.text();
+			alert("Error: " + text);
+			return;
+		}
+		const html = await resp.text();
+		const history = document.getElementById("qa-history");
+		const div = document.createElement("div");
+		div.innerHTML = html;
+		history.appendChild(div.firstChild);
+		form.querySelector("#qa-question").value = "";
+	} finally {
+		submitBtn.disabled = false;
+		loading.classList.add("hidden");
+	}
+}
+
 function toggleAutoRagDropdown(checked) {
 	const dropdown = document.getElementById("autorag_id_dropdown_container");
 	if (dropdown) {

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -673,7 +673,8 @@ export const ResearchQA: FC<ResearchQAProps> = ({
 
 			<form
 				id="qa-form"
-				onSubmit={`submitQuestion(event, '${researchId}')`}
+				data-research-id={researchId}
+				onSubmit="submitQuestion(event)"
 				class="space-y-3"
 			>
 				<input type="hidden" name="_csrf" value={csrfToken} />
@@ -698,6 +699,11 @@ export const ResearchQA: FC<ResearchQAProps> = ({
 					</button>
 				</div>
 			</form>
+
+			<div
+				id="qa-error"
+				class="hidden mt-4 text-sm text-red-600 dark:text-red-400 rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2"
+			/>
 
 			<div
 				id="qa-loading"

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -632,7 +632,7 @@ export const ResearchQAItem: FC<ResearchQAItemProps> = ({
 			</div>
 			{createdAt && (
 				<p class="text-xs text-gray-400 dark:text-gray-500 text-right">
-					{new Date(createdAt).toLocaleString()}
+					{createdAt.slice(0, 16).replace("T", " ")} UTC
 				</p>
 			)}
 		</div>

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -600,6 +600,130 @@ export const ResearchList: FC<ResearchListProps> = (props) => {
 	);
 };
 
+interface ResearchQAItemProps {
+	question: string;
+	answer_html: string;
+	createdAt?: string;
+}
+
+export const ResearchQAItem: FC<ResearchQAItemProps> = ({
+	question,
+	answer_html,
+	createdAt,
+}) => {
+	return (
+		<div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3">
+			<div class="flex items-start gap-2">
+				<span class="text-xs font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide mt-0.5">
+					Q
+				</span>
+				<p class="text-sm font-medium text-gray-900 dark:text-white">
+					{question}
+				</p>
+			</div>
+			<div class="flex items-start gap-2">
+				<span class="text-xs font-semibold text-green-600 dark:text-green-400 uppercase tracking-wide mt-0.5">
+					A
+				</span>
+				<div
+					class="text-sm text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none"
+					dangerouslySetInnerHTML={{ __html: answer_html }}
+				/>
+			</div>
+			{createdAt && (
+				<p class="text-xs text-gray-400 dark:text-gray-500 text-right">
+					{new Date(createdAt).toLocaleString()}
+				</p>
+			)}
+		</div>
+	);
+};
+
+interface ResearchQAProps {
+	researchId: string;
+	questions: Array<{
+		question: string;
+		answer_html: string;
+		created_at?: string;
+	}>;
+	csrfToken: string;
+}
+
+export const ResearchQA: FC<ResearchQAProps> = ({
+	researchId,
+	questions,
+	csrfToken,
+}) => {
+	return (
+		<section class="mt-8 border-t border-gray-200 dark:border-gray-700 pt-6">
+			<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+				Ask a follow-up question
+			</h2>
+
+			<div id="qa-history" class="space-y-4 mb-6">
+				{questions.map((q, i) => (
+					<ResearchQAItem
+						key={String(i)}
+						question={q.question}
+						answer_html={q.answer_html}
+						createdAt={q.created_at}
+					/>
+				))}
+			</div>
+
+			<form
+				id="qa-form"
+				onSubmit={`submitQuestion(event, '${researchId}')`}
+				class="space-y-3"
+			>
+				<input type="hidden" name="_csrf" value={csrfToken} />
+				<textarea
+					name="question"
+					id="qa-question"
+					rows={3}
+					placeholder="Ask a question about this research report..."
+					maxLength={2000}
+					class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+				/>
+				<div class="flex items-center justify-between">
+					<p class="text-xs text-gray-500 dark:text-gray-400">
+						Answers are grounded in the report content.
+					</p>
+					<button
+						type="submit"
+						id="qa-submit"
+						class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					>
+						Ask
+					</button>
+				</div>
+			</form>
+
+			<div
+				id="qa-loading"
+				class="hidden mt-4 text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2"
+			>
+				<svg class="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+					<circle
+						class="opacity-25"
+						cx="12"
+						cy="12"
+						r="10"
+						stroke="currentColor"
+						stroke-width="4"
+					/>
+					<path
+						class="opacity-75"
+						fill="currentColor"
+						d="M4 12a8 8 0 018-8v8H4z"
+					/>
+				</svg>
+				Asking Gemini...
+			</div>
+		</section>
+	);
+};
+
 export const ResearchDetails: FC = (props) => {
 	const researchData = props.research;
 	const mainId = `research-details-main-${researchData.id}`;
@@ -865,6 +989,14 @@ export const ResearchDetails: FC = (props) => {
 						{html(researchData.report_html)}
 					</div>
 				</div>
+			)}
+
+			{researchData.status === 2 && (
+				<ResearchQA
+					researchId={researchData.id}
+					questions={researchData.researchQuestions || []}
+					csrfToken={researchData.csrfToken || ""}
+				/>
 			)}
 		</main>
 	);

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,14 @@ export interface ResearchStatusHistory {
 	status_text: string;
 }
 
+export interface ResearchQuestion {
+	id: string;
+	research_id: string;
+	question: string;
+	answer: string;
+	created_at?: string;
+}
+
 // ============================================
 // Learnings with Source Attribution
 // ============================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,7 @@ export interface ResearchQuestion {
 	id: string;
 	research_id: string;
 	question: string;
-	answer: string;
+	answer: string; // raw markdown — use renderMarkdownReportContent() before rendering
 	created_at?: string;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,6 +140,33 @@ export function safeJsonParse<T>(
 	}
 }
 
+const RATE_LIMIT_BACKOFF_MS = 5000;
+
+export function isRateLimitError(error: unknown): boolean {
+	if (error instanceof Error) {
+		const message = error.message || "";
+		const lastError = (error as { lastError?: string }).lastError || "";
+		const combined = `${message} ${lastError}`.toLowerCase();
+		return (
+			combined.includes("exceeded your current quota") ||
+			combined.includes("too many requests") ||
+			combined.includes("rate limit") ||
+			combined.includes("429")
+		);
+	}
+	return false;
+}
+
+export function getRetryDelay(error: unknown): number {
+	if (error instanceof Error) {
+		const retryMatch = error.message.match(/retry in ([\d.]+)s/i);
+		if (retryMatch) {
+			return Math.ceil(Number.parseFloat(retryMatch[1]) * 1000);
+		}
+	}
+	return RATE_LIMIT_BACKOFF_MS;
+}
+
 export function formatDuration(ms: number): string {
 	// Handle negative or zero values
 	if (ms <= 0) {

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -27,7 +27,14 @@ import {
 } from "./prompts";
 import { storeReportWithR2Fallback } from "./storage";
 import type { ResearchType } from "./types";
-import { getFallbackModel, getModel, getModelThinking, sleep } from "./utils";
+import {
+	getFallbackModel,
+	getModel,
+	getModelThinking,
+	getRetryDelay,
+	isRateLimitError,
+	sleep,
+} from "./utils";
 import { getBrowser, type ResearchBrowser, webSearch } from "./webSearch";
 
 // ============================================
@@ -548,33 +555,6 @@ Generate the report following the structure outlined in your system prompt.`;
 // ============================================
 // Helper Functions
 // ============================================
-
-const RATE_LIMIT_BACKOFF_MS = 5000;
-
-function isRateLimitError(error: unknown): boolean {
-	if (error instanceof Error) {
-		const message = error.message || "";
-		const lastError = (error as { lastError?: string }).lastError || "";
-		const combined = `${message} ${lastError}`.toLowerCase();
-		return (
-			combined.includes("exceeded your current quota") ||
-			combined.includes("too many requests") ||
-			combined.includes("rate limit") ||
-			combined.includes("429")
-		);
-	}
-	return false;
-}
-
-function getRetryDelay(error: unknown): number {
-	if (error instanceof Error) {
-		const retryMatch = error.message.match(/retry in ([\d.]+)s/i);
-		if (retryMatch) {
-			return Math.ceil(Number.parseFloat(retryMatch[1]) * 1000);
-		}
-	}
-	return RATE_LIMIT_BACKOFF_MS;
-}
 
 /**
  * Format error messages for user display

--- a/tests/integration/qa.test.ts
+++ b/tests/integration/qa.test.ts
@@ -1,0 +1,161 @@
+import { env } from "cloudflare:test";
+import { generateText } from "ai";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { D1QB } from "workers-qb";
+import { app } from "../../src/index";
+import { migrations } from "../../src/migrations";
+import { getFallbackModel, getModel } from "../../src/utils";
+
+// Mock the 'ai' module
+vi.mock("ai", () => ({
+	generateObject: vi.fn(),
+	generateText: vi.fn(),
+}));
+
+// Mock utils — keep real implementations for isRateLimitError, buildSearchFilters, etc.
+vi.mock("../../src/utils", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/utils")>();
+	return {
+		...actual,
+		getModel: vi.fn(),
+		getFallbackModel: vi.fn(),
+		getModelThinking: vi.fn(),
+		sleep: vi.fn().mockResolvedValue(undefined),
+	};
+});
+
+// Mock webSearch to avoid node-html-markdown incompatibility with workerd
+vi.mock("../../src/webSearch", () => ({
+	getBrowser: vi.fn(),
+	webSearch: vi.fn(),
+}));
+
+const testEnv = {
+	...env,
+	GOOGLE_API_KEY: "test-api-key",
+};
+
+const CSRF_TOKEN = "test-csrf-token-qa-tests";
+const CSRF_COOKIE = `__csrf=${CSRF_TOKEN}`;
+
+async function makeAskRequest(
+	researchId: string,
+	question: string,
+): Promise<Response> {
+	const formData = new FormData();
+	formData.append("question", question);
+	return app.request(
+		`/details/${researchId}/ask`,
+		{
+			method: "POST",
+			headers: {
+				Cookie: CSRF_COOKIE,
+				"x-csrf-token": CSRF_TOKEN,
+			},
+			body: formData,
+		},
+		testEnv,
+	);
+}
+
+async function insertResearch(
+	id: string,
+	status: number,
+	result: string | null = null,
+): Promise<void> {
+	await env.DB.prepare(
+		`INSERT INTO researches (id, query, depth, breadth, questions, status, result, user)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(id, "Test topic", "3", "3", "[]", status, result, "test-user")
+		.run();
+}
+
+describe("POST /details/:id/ask", () => {
+	beforeAll(async () => {
+		const qb = new D1QB(env.DB);
+		await qb.migrations({ migrations, tableName: "d1_migrations" }).apply();
+	});
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		(getModel as ReturnType<typeof vi.fn>).mockReturnValue({
+			id: "test-model",
+		});
+		(getFallbackModel as ReturnType<typeof vi.fn>).mockReturnValue({
+			id: "test-fallback-model",
+		});
+		(generateText as ReturnType<typeof vi.fn>).mockResolvedValue({
+			text: "Test answer",
+		});
+	});
+
+	test("returns 404 for unknown research id", async () => {
+		const resp = await makeAskRequest("nonexistent-qa-research", "What is this?");
+		expect(resp.status).toBe(404);
+	});
+
+	test("returns 400 for empty question", async () => {
+		const resp = await makeAskRequest("any-qa-id", "");
+		expect(resp.status).toBe(400);
+		const body = await resp.text();
+		expect(body).toContain("Question is required");
+	});
+
+	test("returns 400 for in-progress research (status=1)", async () => {
+		await insertResearch("qa-in-progress-research", 1, "some report content");
+		const resp = await makeAskRequest(
+			"qa-in-progress-research",
+			"What is this?",
+		);
+		expect(resp.status).toBe(400);
+		const body = await resp.text();
+		expect(body).toContain("not yet complete");
+	});
+
+	test("returns 200 HTML fragment and persists Q&A to D1 for completed research", async () => {
+		await insertResearch(
+			"qa-completed-research",
+			2,
+			"This is the full report about AI trends.",
+		);
+		const resp = await makeAskRequest(
+			"qa-completed-research",
+			"What does the report say?",
+		);
+
+		expect(resp.status).toBe(200);
+		const html = await resp.text();
+		expect(html).toContain("What does the report say?");
+		expect(html).toContain("Test answer");
+
+		const row = await env.DB.prepare(
+			"SELECT * FROM research_questions WHERE research_id = ?",
+		)
+			.bind("qa-completed-research")
+			.first<{ question: string; answer: string }>();
+		expect(row).not.toBeNull();
+		expect(row?.question).toBe("What does the report say?");
+		expect(row?.answer).toBe("Test answer");
+	});
+
+	test("returns 429 when per-research question limit (50) is reached", async () => {
+		const researchId = "qa-limit-research";
+		await insertResearch(researchId, 2, "Report content for limit test.");
+
+		// Insert 50 questions directly to reach the cap
+		for (let i = 0; i < 50; i++) {
+			await env.DB.prepare(
+				`INSERT INTO research_questions (id, research_id, question, answer)
+         VALUES (?, ?, ?, ?)`,
+			)
+				.bind(`qa-limit-q-${i}`, researchId, `Question ${i}`, `Answer ${i}`)
+				.run();
+		}
+
+		const resp = await makeAskRequest(researchId, "One more question?");
+		expect(resp.status).toBe(429);
+		const body = await resp.text();
+		expect(body).toContain("Maximum 50 questions");
+	});
+});

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -19,13 +19,17 @@ vi.mock("ai", () => ({
 	generateText: vi.fn(),
 }));
 
-// Mock the utils module
-vi.mock("../../src/utils", () => ({
-	getModel: vi.fn(),
-	getFallbackModel: vi.fn(),
-	getModelThinking: vi.fn(),
-	sleep: vi.fn().mockResolvedValue(undefined),
-}));
+// Mock the utils module, keeping non-mocked exports (isRateLimitError, getRetryDelay, etc.)
+vi.mock("../../src/utils", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/utils")>();
+	return {
+		...actual,
+		getModel: vi.fn(),
+		getFallbackModel: vi.fn(),
+		getModelThinking: vi.fn(),
+		sleep: vi.fn().mockResolvedValue(undefined),
+	};
+});
 
 // Mock webSearch to avoid loading node-html-markdown (incompatible with workerd)
 vi.mock("../../src/webSearch", () => ({

--- a/tests/unit/prompts.test.ts
+++ b/tests/unit/prompts.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { REPORT_QA_PROMPT } from "../../src/prompts";
+
+describe("REPORT_QA_PROMPT", () => {
+	test("should return a non-empty string", () => {
+		const prompt = REPORT_QA_PROMPT();
+		expect(typeof prompt).toBe("string");
+		expect(prompt.length).toBeGreaterThan(0);
+	});
+
+	test("should instruct to answer only from the report", () => {
+		const prompt = REPORT_QA_PROMPT();
+		expect(prompt).toContain("ONLY based on information present in the report");
+	});
+
+	test("should instruct to acknowledge missing information", () => {
+		const prompt = REPORT_QA_PROMPT();
+		expect(prompt).toContain(
+			"does not contain enough information to answer the question, say so clearly",
+		);
+	});
+});

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
 	buildSearchFilters,
 	formatDuration,
+	getRetryDelay,
+	isRateLimitError,
 	normalizeDomain,
 	safeJsonParse,
 	timeAgo,
@@ -263,6 +265,66 @@ describe("formatDuration", () => {
 
 	test("should format fractional days", () => {
 		expect(formatDuration(129600000)).toBe("1.5 days");
+	});
+});
+
+describe("isRateLimitError", () => {
+	test("should return true for quota exceeded message", () => {
+		const err = new Error("You exceeded your current quota.");
+		expect(isRateLimitError(err)).toBe(true);
+	});
+
+	test("should return true for too many requests message", () => {
+		const err = new Error("too many requests");
+		expect(isRateLimitError(err)).toBe(true);
+	});
+
+	test("should return true for rate limit message", () => {
+		const err = new Error("Rate limit reached");
+		expect(isRateLimitError(err)).toBe(true);
+	});
+
+	test("should return true for 429 in message", () => {
+		const err = new Error("HTTP 429 error");
+		expect(isRateLimitError(err)).toBe(true);
+	});
+
+	test("should return false for unrelated errors", () => {
+		const err = new Error("Network error");
+		expect(isRateLimitError(err)).toBe(false);
+	});
+
+	test("should return false for non-Error values", () => {
+		expect(isRateLimitError("some string")).toBe(false);
+		expect(isRateLimitError(null)).toBe(false);
+		expect(isRateLimitError(undefined)).toBe(false);
+	});
+
+	test("should be case-insensitive", () => {
+		const err = new Error("RATE LIMIT exceeded");
+		expect(isRateLimitError(err)).toBe(true);
+	});
+});
+
+describe("getRetryDelay", () => {
+	test("should return delay from retry message", () => {
+		const err = new Error("Please retry in 30s after the quota is reset.");
+		expect(getRetryDelay(err)).toBe(30000);
+	});
+
+	test("should return default delay when no retry time in message", () => {
+		const err = new Error("Rate limit exceeded");
+		expect(getRetryDelay(err)).toBe(5000);
+	});
+
+	test("should return default delay for non-Error values", () => {
+		expect(getRetryDelay("not an error")).toBe(5000);
+		expect(getRetryDelay(null)).toBe(5000);
+	});
+
+	test("should handle fractional seconds", () => {
+		const err = new Error("retry in 1.5s");
+		expect(getRetryDelay(err)).toBe(1500);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Adds a persistent Q&A panel at the bottom of the research details page, visible only for completed researches (status=2)
- Users can ask follow-up questions grounded in the existing report content via Gemini
- Q&A pairs are saved to a new `research_questions` D1 table and reload on page revisit
- Answers are rendered as markdown HTML matching the existing report style

## Related Issue

Prodboard issue: 71d6659b474c7cc8 — [I] [workers-research] Inline Q&A panel for asking follow-up questions against completed research reports

## Changes

- **`src/migrations.ts`**: Added migration `0012_create_research_questions.sql` with the new table and index
- **`src/types.ts`**: Added `ResearchQuestion` interface
- **`src/prompts.ts`**: Added `REPORT_QA_PROMPT` — instructs Gemini to answer only from report content
- **`src/index.tsx`**: Added `POST /details/:id/ask` route (validates input, fetches report, calls Gemini, stores Q&A); updated `GET /details/:id` to load Q&A history for completed researches
- **`src/templates/layout.tsx`**: Added `ResearchQAItem` and `ResearchQA` JSX components; mounted `ResearchQA` in `ResearchDetails` for completed researches
- **`src/static/core.js`**: Added `submitQuestion` async function for HTMX-free form submit with loading state

## Test Plan

- [x] `tsc` passes (no TypeScript errors)
- [x] All 184 existing tests pass (`npm test`)
- [x] `npm run lint` passes (Biome)
- [ ] Manual: create a research, wait for completion, navigate to details, ask a question — answer appears inline without page reload
- [ ] Manual: reload page — Q&A history persists
- [ ] Manual: in-progress research — Q&A panel is not shown